### PR TITLE
Bug in parseDate

### DIFF
--- a/SSDataKit/SSRemoteManagedObject.m
+++ b/SSDataKit/SSRemoteManagedObject.m
@@ -208,7 +208,7 @@
 
 		// Timezone
 		else if (len == 25 && str[22] == ':') {
-			strncpy(newStr, str, 22);    
+			strncpy(newStr, str, 22);
 			strncpy(newStr + 22, str + 23, 2);
 		}
 


### PR DESCRIPTION
I referenced the parser in SSToolkit and it looks like there's a typo.

There are no tests, but without this change, my dates (from Rails to_json) aren't able to be parsed. After the change, everything works fine.
