### PR TITLE
Fix update bug from NSFetchedResultsControllerDelegate docs

### DIFF
--- a/SSDataKit/SSManagedTableViewController.m
+++ b/SSDataKit/SSManagedTableViewController.m
@@ -184,7 +184,7 @@
 		}
 
         case NSFetchedResultsChangeUpdate: {
-            [self configureCell:[tableView cellForRowAtIndexPath:indexPath] atIndexPath:indexPath];
+            [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
             break;
 		}
 


### PR DESCRIPTION
The original code came from the NSFetchedResultsControllerDelegate docs which contains a bug. Basically using configureCell may update a cell with incorrect data when more than one cell is being updated at the same time because a mismatch between the state of the tableview and the model.

Ole explains it pretty well here.

http://oleb.net/blog/2013/02/nsfetchedresultscontroller-documentation-bug/
