### PR TITLE
Ensure that remoteID is always a number value

### DIFF
--- a/SSDataKit/SSRemoteManagedObject.m
+++ b/SSDataKit/SSRemoteManagedObject.m
@@ -78,7 +78,7 @@
 	}
 
 	// Extract the remoteID from the dictionary
-	NSNumber *remoteID = @([[dictionary objectForKey:@"id"] intValue]);
+	NSNumber *remoteID = @([[dictionary objectForKey:@"id"] integerValue]);
 
 	// If there isn't a remoteID, we won't find the object. Return nil.
 	if (!remoteID || remoteID.integerValue == 0) {
@@ -115,7 +115,7 @@
 	}
 
 	// Extract the remoteID from the dictionary
-	NSNumber *remoteID = @([[dictionary objectForKey:@"id"] intValue]);
+	NSNumber *remoteID = @([[dictionary objectForKey:@"id"] integerValue]);
 
 	// If there isn't a remoteID, we won't find the object. Return nil.
 	if (!remoteID || remoteID.integerValue == 0) {
@@ -145,7 +145,7 @@
 
 - (void)unpackDictionary:(NSDictionary *)dictionary {
 	if (!self.isRemote) {
-		self.remoteID = @([[dictionary objectForKey:@"id"] intValue]);
+		self.remoteID = @([[dictionary objectForKey:@"id"] integerValue]);
 	}
 
 	if ([self respondsToSelector:@selector(setCreatedAt:)]) {


### PR DESCRIPTION
I work with a lot of (subpar) APIs. Some are nicer than others, but one I'm working with in particular sends all JSON over as string values, no integers. With remoteIDs, this causes a crash when the value for @"id" is a string and not an int. Easy enough to just cast it.
