### PR TITLE
Squelch implementing deprecated method warning.

### DIFF
--- a/SSDataKit/SSManagedObject.m
+++ b/SSDataKit/SSManagedObject.m
@@ -62,14 +62,20 @@ static NSString *const kURIRepresentationKey = @"URIRepresentation";
 }
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 + (NSManagedObjectContext *)mainContext {
 	return [self mainQueueContext];
 }
+#pragma clang diagnostic pop
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 + (BOOL)hasMainContext {
 	return [self hasMainQueueContext];
 }
+#pragma clang diagnostic pop
 
 
 + (NSPersistentStoreCoordinator *)persistentStoreCoordinator {


### PR DESCRIPTION
The implementation of `+mainContext` and `+hasMainContext` were both triggering warnings for me as I have `-Wdeprecated-implementations` turned on. This patch will make clang ignore these two specific methods but leave the warning on for everything else.
