### PR TITLE
Refactor SSFilterableFetchedResultsController filter updates.

### DIFF
--- a/SSDataKit/SSFilterableFetchedResultsController.h
+++ b/SSDataKit/SSFilterableFetchedResultsController.h
@@ -21,6 +21,7 @@
 @property (nonatomic, readonly) NSString *cacheName;
 @property (nonatomic, assign) id<NSFetchedResultsControllerDelegate> delegate;
 @property (nonatomic, readonly) NSArray *fetchedObjects;
+@property (nonatomic, readonly) NSArray *unfilteredFetchedObjects;
 @property (nonatomic, readonly) NSArray *sections;
 
 // NSFetchedResultsController

--- a/SSDataKit/SSFilterableFetchedResultsController.m
+++ b/SSDataKit/SSFilterableFetchedResultsController.m
@@ -277,6 +277,11 @@
 }
 
 
+- (NSArray *)unfilteredFetchedObjects {
+	return self.fetchedResultsController.fetchedObjects;
+}
+
+
 - (NSArray *)sections {
 	if (self.currentFilter == nil) {
 		return [self.fetchedResultsController sections];


### PR DESCRIPTION
Currently, whenever there's an change in the filter in a SSFilterableFetchedResultsController, the entire table is deleted and the new results are filtered.

With this change, only objects that do not pass the new filter are deleted, objects that pass both filters are moved if necessary, and objects that only pass the new filter (but not the old one) are inserted.

Thanks for all your hard work on this project! It seriously helped my understanding and use of CoreData.
