### PR TITLE
fix main queue context race condition

### DIFF
--- a/SSDataKit/SSManagedObject.m
+++ b/SSDataKit/SSManagedObject.m
@@ -52,8 +52,9 @@ static NSString *const kURIRepresentationKey = @"URIRepresentation";
 
 + (NSManagedObjectContext *)mainQueueContext {
 	if (!__mainQueueContext) {
-		__mainQueueContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-		[__mainQueueContext setParentContext:[self privateQueueContext]];
+		NSManagedObjectContext *mxct = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+		[mxct setParentContext:[self privateQueueContext]];
+        __mainQueueContext = mxct;
 	}
 	return __mainQueueContext;
 }


### PR DESCRIPTION
It's possible to attempt to create a child context of the mainQueueContext (on a different thread) after the NSManagedObjectContext is initialized, but not before its parent context is set. This becomes likely since [self privateQueueContext] can take a long time to finish. This change prevents that race condition. 
