### PR TITLE
Fix for possible infinite loop for persistent store in bad state

### DIFF
--- a/SSDataKit/SSManagedObject.m
+++ b/SSDataKit/SSManagedObject.m
@@ -213,7 +213,7 @@ NSString *kPersistentStoreLock = @"kSSPeristentStoreLock";
 
 	// Delete old persistent store
 	NSURL *url = [self persistentStoreURL];
-	NSPersistentStoreCoordinator *psc = [SSManagedObject persistentStoreCoordinator];
+	NSPersistentStoreCoordinator *psc = [self persistentStoreCoordinator];
 	if ([psc removePersistentStore:psc.persistentStores.lastObject error:nil]) {
 		[SSManagedObject removeSQLiteFiles];
 


### PR DESCRIPTION
There exists an issue that if the `NSPersistentStroeCoordinator` failed to add a persistent store, then the coordinator was in a bad state. In this case, the code just continued to use that coordinator even though it was in a bad state, and then performing fetches or saves on the coordinator would cause a crash.

The fix only sets the static coordinator upon successfully adding a persistentStore, otherwise leaving it as nil. The second part of this is making it so that if the coordinator is nil, we still allow the code to run to make a new one to it can try and make it again.
